### PR TITLE
Syntax fixes

### DIFF
--- a/syntax/xml.vim
+++ b/syntax/xml.vim
@@ -4,7 +4,7 @@
 " Previous Maintainer:	Johannes Zellner <johannes@zellner.org>
 "		Author and previous maintainer:
 "		Paul Siegmann <pauls@euronet.nl>
-" Last Change:	2013 Jun 07
+" Last Change:	2019 Sep 22
 " Filenames:	*.xml
 " $Id: xml.vim,v 1.3 2006/04/11 21:32:00 vimboss Exp $
 
@@ -123,7 +123,7 @@ endif
 "  ^^^
 "
 syn match   xmlTagName
-    \ +<\@1<=[^ /!?<>"']\++
+    \ +\%(<\|</\)\@2<=[^ /!?<>"']\++
     \ contained
     \ contains=xmlNamespace,xmlAttribPunct,@xmlTagHook
     \ display
@@ -158,11 +158,11 @@ if exists('g:xml_syntax_folding')
     " </tag>
     " ^^^^^^
     "
-    syn match   xmlEndTag
-	\ +</[^ /!?<>"']\+>+
+    syn region   xmlEndTag
+	\ matchgroup=xmlTag start=+</[^ /!?<>"']\@=+
+	\ matchgroup=xmlTag end=+>+
 	\ contained
-	\ contains=xmlNamespace,xmlAttribPunct,@xmlTagHook
-
+	\ contains=xmlTagName,xmlNamespace,xmlAttribPunct,@xmlTagHook
 
     " tag elements with syntax-folding.
     " NOTE: NO HIGHLIGHTING -- highlighting is done by contained elements
@@ -182,7 +182,7 @@ if exists('g:xml_syntax_folding')
 	\ start=+<\z([^ /!?<>"']\+\)+
 	\ skip=+<!--\_.\{-}-->+
 	\ end=+</\z1\_\s\{-}>+
-	\ matchgroup=xmlEndTag end=+/>+
+	\ end=+/>+
 	\ fold
 	\ contains=xmlTag,xmlEndTag,xmlCdata,xmlRegion,xmlComment,xmlEntity,xmlProcessing,@xmlRegionHook,@Spell
 	\ keepend
@@ -199,9 +199,10 @@ else
 	\ matchgroup=xmlTag end=+>+
 	\ contains=xmlError,xmlTagName,xmlAttrib,xmlEqual,xmlString,@xmlStartTagHook
 
-    syn match   xmlEndTag
-	\ +</[^ /!?<>"']\+>+
-	\ contains=xmlNamespace,xmlAttribPunct,@xmlTagHook
+    syn region   xmlEndTag
+	\ matchgroup=xmlTag start=+</[^ /!?<>"']\@=+
+	\ matchgroup=xmlTag end=+>+
+	\ contains=xmlTagName,xmlNamespace,xmlAttribPunct,@xmlTagHook
 
 endif
 


### PR DESCRIPTION
Fixed xmlEndTag to match xmlTag.

This change is per the gist linked from vim/vim#884, and at amadeus/vim-xml@d7c54d4d7.

I confess that I am not intimate with the details of how this fix is working.  But I do know that sheerun/vim-polyglot includes these changes (since sheerun/vim-polyglot@2c59360e0 I think), so that gives us some reason to believe that they're sound.

If we do have questions about these changes, perhaps we'll be able to get @amadeus to say something about them - encouraged, I hope, by the prospect of finally getting them into the vim runtime.

I have not included the change at amadeus/vim-xml@d8ce1c946.