### PR TITLE
indent: Fix recently broken changes regarding comment and non-xml indent

### DIFF
--- a/test/INDENT/07/input.xml
+++ b/test/INDENT/07/input.xml
@@ -1,6 +1,15 @@
 <some>
+    <open-tag-with-dashes>
+        <test/>
+        <!-- abc -->
+    </open-tag-with-dashes>
     <multiline-tag
         attr1="1" attr2="2"
         attr3="1" attr4="2" />
     <another-tag />
+<!-- test comment -->
+    <another-multiline-tag
+        attr1="1" attr2="2"
+      attr3="1" attr4="2">1</another-multiline-tag>
+        <!-- test comment -->
 </some>

--- a/test/INDENT/07/reference.xml
+++ b/test/INDENT/07/reference.xml
@@ -1,6 +1,15 @@
 <some>
+  <open-tag-with-dashes>
+    <test/>
+    <!-- abc -->
+  </open-tag-with-dashes>
   <multiline-tag
     attr1="1" attr2="2"
     attr3="1" attr4="2" />
+  <!-- test comment -->
   <another-tag />
+  <another-multiline-tag
+    attr1="1" attr2="2"
+    attr3="1" attr4="2">1</another-multiline-tag>
+  <!-- test comment -->
 </some>


### PR DESCRIPTION
I do not not know how needed these features are or if this is the best implementation. Anyways, I am fixing my previous commit by introducing regex searching over multiple line for a closing '>' regarding indentation of comments.

All tests pass.