### PR TITLE
Fix wrapping blocks of text within XML

### DIFF
--- a/autoload/xmlformat.vim
+++ b/autoload/xmlformat.vim
@@ -37,9 +37,10 @@ func! xmlformat#Format() abort
     " Keep empty input lines?
     if empty(line)
       call add(result, '')
+      let current += 1
       continue
     elseif line !~# '<[/]\?[^>]*>'
-      let nextmatch = match(list, '<[/]\?[^>]*>', current)
+      let nextmatch = match(list, '^\s*$\|<[/]\?[^>]*>', current)
       if nextmatch > -1
         let lineEnd = nextmatch
       else

--- a/autoload/xmlformat.vim
+++ b/autoload/xmlformat.vim
@@ -40,10 +40,13 @@ func! xmlformat#Format() abort
       continue
     elseif line !~# '<[/]\?[^>]*>'
       let nextmatch = match(list, '<[/]\?[^>]*>', current)
-      if nextmatch > -1 
-        let line .= ' '. join(list[(current + 1):(nextmatch-1)], " ")
-        call remove(list, current+1, nextmatch-1)
+      if nextmatch > -1
+        let lineEnd = nextmatch
+      else
+        let lineEnd = len(list)
       endif
+      let line .= ' '. join(list[(current + 1):(lineEnd-1)], " ")
+      call remove(list, current+1, lineEnd-1)
     endif
     " split on `>`, but don't split on very first opening <
     " this means, items can be like ['<tag>', 'tag content</tag>']

--- a/test/AUTOFORMAT/07/reference.xml
+++ b/test/AUTOFORMAT/07/reference.xml
@@ -2,7 +2,10 @@
 <format>
   <tag>
     Very long text very long text very long text very long text very long text
-    very long text. Another Very long text very long text very long
-    text very long text very long text very long text.
+    very long text.
+
+
+    Another Very long text very long text very long text very long text very
+    long text very long text.
   </tag>
 </format>

--- a/test/AUTOFORMAT/08/reference.xml
+++ b/test/AUTOFORMAT/08/reference.xml
@@ -2,7 +2,10 @@
 <format>
   <tag>
     Very long text very long text very long text very long text very long text
-    very long text. Another Very long text very long text very long
-    text very long text very long text very long text.
+    very long text.
+
+
+    Another Very long text very long text very long text very long text very
+    long text very long text.
   </tag>
 </format>

--- a/test/AUTOFORMAT/11/reference.xml
+++ b/test/AUTOFORMAT/11/reference.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <tag>
   A paragraph split up in multiple short lines.
+
 </tag>

--- a/test/AUTOFORMAT/16/cmd
+++ b/test/AUTOFORMAT/16/cmd
@@ -1,0 +1,8 @@
+#!/bin/sh
+#set -x
+vim $VIM_DEFAULT_ARG \
+  -c ':so $VIM_XML_RT/autoload/xmlformat.vim' \
+  -c ':set formatexpr=xmlformat#Format() ts=2 sw=0 sts=-1 tw=80' \
+  -c 'norm! gggqG' \
+  -c ':saveas! output.xml' \
+  -c ':q!'  input.xml

--- a/test/AUTOFORMAT/16/input.xml
+++ b/test/AUTOFORMAT/16/input.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<format>
+
+  <tag>
+      A relatively short line.
+      And text that should be wrapped up with the above.
+  </tag>
+
+</format>

--- a/test/AUTOFORMAT/16/reference.xml
+++ b/test/AUTOFORMAT/16/reference.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<format>
+
+  <tag>
+    A relatively short line. And text that should be wrapped up with the
+    above.
+  </tag>
+
+</format>

--- a/test/AUTOFORMAT/17/cmd
+++ b/test/AUTOFORMAT/17/cmd
@@ -1,0 +1,8 @@
+#!/bin/sh
+#set -x
+vim $VIM_DEFAULT_ARG \
+  -c ':so $VIM_XML_RT/autoload/xmlformat.vim' \
+  -c ':set formatexpr=xmlformat#Format() ts=2 sw=0 sts=-1 tw=80' \
+  -c 'norm! gggq}' \
+  -c ':saveas! output.xml' \
+  -c ':q!'  input.xml

--- a/test/AUTOFORMAT/17/input.xml
+++ b/test/AUTOFORMAT/17/input.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<format>
+  <tag>
+    A relatively short line.
+    And text that should be wrapped up with the above.
+
+  </tag>
+</format>

--- a/test/AUTOFORMAT/17/reference.xml
+++ b/test/AUTOFORMAT/17/reference.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<format>
+  <tag>
+    A relatively short line. And text that should be wrapped up with the
+    above.
+
+  </tag>
+</format>


### PR DESCRIPTION
Currently the XML formatter has three issues with line wrapping text, which this PR seeks to address:

1. Empty lines are not always preserved.
2. Empty lines can trigger duplicated text and failure to join and wrap short lines.
3. Wrapping a region of text within a tag (when that region does not include an end tag), causes failure to join and wrap short lines.

Here is an example document that demonstrates the first three issues. Put your cursor on line 1 and run `gqit`.

```xml
<document>
  <tag1>
    some text that I'd like to wrap at 80 chars
    and I need to have this line wrapped with previous

  </tag1>

  <tag2>
    more text that I'd like to wrap at 80 chars
    with another line wrapped with previous
  </tag2>

  <tag3>
    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
    incididunt ut labore et dolore magna aliqua. Ut enim ad minim

    make sure empty lines are respected
  </tag3>
</document>
```

Here is the result:

```xml
<document>
  <tag1>
    some text that I'd like to wrap at 80 chars and I need to have this line
    wrapped with previous
  </tag1>

  <tag2>
    more text that I'd like to wrap at 80 chars
    with another line wrapped with previous with another line wrapped with
    previous
  </tag2>

  <tag3>
    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
    tempor
    incididunt ut labore et dolore magna aliqua. Ut enim ad minim incididunt
    ut labore et dolore magna aliqua. Ut enim ad minim make sure empty
    lines are respected
  </tag3>
</document>
```

The contents of `<tag1>` are wrapped as expected, but the contents of `<tag2>` fail to join the first line with the second and then duplicates the second line. The empty line within `<tag3>` is unexpectedly erased while those between tags are preserved.

As an example of the third issue, revert to the original example and then run `:g/<tag/norm gq}` (or do `gq` on a line-wise visual select of the contents of any tag without including the end tag).

Note the contents of `<tag2>` are now wrapped as expected, but `<tag1>` and `<tag3>` don't join the shorter lines.

```xml
<document>
  <tag1>
    some text that I'd like to wrap at 80 chars
    and I need to have this line wrapped with previous

  </tag1>

  <tag2>
    more text that I'd like to wrap at 80 chars with another line wrapped
    with previous
  </tag2>

  <tag3>
    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
    tempor
    incididunt ut labore et dolore magna aliqua. Ut enim ad minim

    make sure empty lines are respected
  </tag3>
</document>
```

This PR addresses the above issues. Regardless of whether you run `gqit` on line 1 or `:g/<tag/norm gq}`, the result will be the following:

```xml
<document>
  <tag1>
    some text that I'd like to wrap at 80 chars and I need to have this line
    wrapped with previous

  </tag1>

  <tag2>
    more text that I'd like to wrap at 80 chars with another line wrapped
    with previous
  </tag2>

  <tag3>
    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
    tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim

    make sure empty lines are respected
  </tag3>
</document>
```

All three inner tags are correctly wrapped as expected, and blank lines are preserved in each case, matching the expected behavior of `gq` for other file types.