### PR TITLE
Speed up highlighting of XML and refactor its syntax script

### DIFF
--- a/syntax/xml.vim
+++ b/syntax/xml.vim
@@ -4,13 +4,14 @@
 " Repository: https://github.com/chrisbra/vim-xml-ftplugin
 " Previous Maintainer: Johannes Zellner <johannes@zellner.org>
 " Author: Paul Siegmann <pauls@euronet.nl>
-" Last Changed:	Nov 03, 2019
+" Last Changed:	30 Jun 2026
 " Filenames:	*.xml
 " Last Change:
 " 20190923 - Fix xmlEndTag to match xmlTag (vim/vim#884)
 " 20190924 - Fix xmlAttribute property (amadeus/vim-xml@d8ce1c946)
 " 20191103 - Enable spell checking globally
 " 20210428 - Improve syntax synchronizing
+" 20260630 - Improve performance
 
 " CONFIGURATION:
 "   syntax folding can be turned on by
@@ -109,14 +110,25 @@ syn match   xmlAttrib
 "
 if exists("g:xml_namespace_transparent")
 syn match   xmlNamespace
-    \ +\(<\|</\)\@2<=[^ /!?<>"':]\+[:]\@=+
+    \ +<[^ /!?<>"':]\+[:]\@=+lc=1
+    \ contained
+    \ contains=@xmlNamespaceHook
+    \ transparent
+    \ display
+syn match   xmlNamespace
+    \ +</[^ /!?<>"':]\+[:]\@=+lc=2
     \ contained
     \ contains=@xmlNamespaceHook
     \ transparent
     \ display
 else
 syn match   xmlNamespace
-    \ +\(<\|</\)\@2<=[^ /!?<>"':]\+[:]\@=+
+    \ +<[^ /!?<>"':]\+[:]\@=+lc=1
+    \ contained
+    \ contains=@xmlNamespaceHook
+    \ display
+syn match   xmlNamespace
+    \ +</[^ /!?<>"':]\+[:]\@=+lc=2
     \ contained
     \ contains=@xmlNamespaceHook
     \ display
@@ -133,7 +145,12 @@ endif
 "  ^^^
 "
 syn match   xmlTagName
-    \ +\%(<\|</\)\@2<=[^ /!?<>"']\++
+    \ +<[^ /!?<>"']\++lc=1
+    \ contained
+    \ contains=xmlNamespace,xmlAttribPunct,@xmlTagHook
+    \ display
+syn match   xmlTagName
+    \ +</[^ /!?<>"']\++lc=2
     \ contained
     \ contains=xmlNamespace,xmlAttribPunct,@xmlTagHook
     \ display

--- a/syntax/xml.vim
+++ b/syntax/xml.vim
@@ -110,25 +110,25 @@ syn match   xmlAttrib
 "
 if exists("g:xml_namespace_transparent")
 syn match   xmlNamespace
-    \ +<[^ /!?<>"':]\+[:]\@=+lc=1
+    \ +<[^ /!?<>"':]\+\ze:+lc=1
     \ contained
     \ contains=@xmlNamespaceHook
     \ transparent
     \ display
 syn match   xmlNamespace
-    \ +</[^ /!?<>"':]\+[:]\@=+lc=2
+    \ +</[^ /!?<>"':]\+\ze:+lc=2
     \ contained
     \ contains=@xmlNamespaceHook
     \ transparent
     \ display
 else
 syn match   xmlNamespace
-    \ +<[^ /!?<>"':]\+[:]\@=+lc=1
+    \ +<[^ /!?<>"':]\+\ze:+lc=1
     \ contained
     \ contains=@xmlNamespaceHook
     \ display
 syn match   xmlNamespace
-    \ +</[^ /!?<>"':]\+[:]\@=+lc=2
+    \ +</[^ /!?<>"':]\+\ze:+lc=2
     \ contained
     \ contains=@xmlNamespaceHook
     \ display
@@ -169,7 +169,7 @@ if exists('g:xml_syntax_folding')
     " s^^^^^^^^^^^^^^^e
     "
     syn region   xmlTag
-	\ matchgroup=xmlTag start=+<[^ /!?<>"']\@=+
+	\ matchgroup=xmlTag start=+<\ze[^ /!?<>"']+
 	\ matchgroup=xmlTag end=+>+
 	\ contained
 	\ contains=xmlError,xmlTagName,xmlAttrib,xmlEqual,xmlString,@xmlStartTagHook
@@ -186,7 +186,7 @@ if exists('g:xml_syntax_folding')
     " ^^^^^^
     "
     syn region   xmlEndTag
-	\ matchgroup=xmlTag start=+</[^ /!?<>"']\@=+
+	\ matchgroup=xmlTag start=+</\ze[^ /!?<>"']+
 	\ matchgroup=xmlTag end=+>+
 	\ contained
 	\ contains=xmlTagName,xmlNamespace,xmlAttribPunct,@xmlTagHook
@@ -222,12 +222,12 @@ else
     " - xmlRegion not defined
     "
     syn region   xmlTag
-	\ matchgroup=xmlTag start=+<[^ /!?<>"']\@=+
+	\ matchgroup=xmlTag start=+<\ze[^ /!?<>"']+
 	\ matchgroup=xmlTag end=+>+
 	\ contains=xmlError,xmlTagName,xmlAttrib,xmlEqual,xmlString,@xmlStartTagHook
 
     syn region   xmlEndTag
-	\ matchgroup=xmlTag start=+</[^ /!?<>"']\@=+
+	\ matchgroup=xmlTag start=+</\ze[^ /!?<>"']+
 	\ matchgroup=xmlTag end=+>+
 	\ contains=xmlTagName,xmlNamespace,xmlAttribPunct,@xmlTagHook
 

--- a/syntax/xml.vim
+++ b/syntax/xml.vim
@@ -94,7 +94,7 @@ syn match   xmlEqual +=+ display
 "      ^^^^^^^^^^^^^
 "
 syn match   xmlAttrib
-    \ +\%#=1[-'"<]\@1<!\<[a-zA-Z:_][-.0-9a-zA-Z:_]*\>['"]\@!+
+    \ +\%#=1[-/!?<>"']\@1<!\<[a-zA-Z:_][-.0-9a-zA-Z:_]*\>['"]\@!+
     \ contained
     \ contains=xmlAttribPunct,@xmlAttribHook
     \ display

--- a/syntax/xml.vim
+++ b/syntax/xml.vim
@@ -100,6 +100,12 @@ syn match   xmlAttrib
     \ display
 
 
+if exists("g:xml_namespace_transparent")
+    command! -nargs=+ XmlTransparent <args> transparent
+else
+    command! -nargs=+ XmlTransparent <args>
+endif
+
 " namespace spec
 "
 " PROVIDES: @xmlNamespaceHook
@@ -109,31 +115,18 @@ syn match   xmlAttrib
 " <xsl:for-each select = "lola">
 "  ^^^
 "
-if exists("g:xml_namespace_transparent")
-syn match   xmlNamespace
-    \ +<[^ /!?<>"':]\+\ze:+lc=1
-    \ contained
-    \ contains=@xmlNamespaceHook
-    \ transparent
-    \ display
-syn match   xmlNamespace
-    \ +</[^ /!?<>"':]\+\ze:+lc=2
-    \ contained
-    \ contains=@xmlNamespaceHook
-    \ transparent
-    \ display
-else
-syn match   xmlNamespace
+XmlTransparent syn match   xmlNamespace
     \ +<[^ /!?<>"':]\+\ze:+lc=1
     \ contained
     \ contains=@xmlNamespaceHook
     \ display
-syn match   xmlNamespace
+XmlTransparent syn match   xmlNamespace
     \ +</[^ /!?<>"':]\+\ze:+lc=2
     \ contained
     \ contains=@xmlNamespaceHook
     \ display
-endif
+
+delcommand XmlTransparent
 
 
 " tag name
@@ -158,40 +151,48 @@ syn match   xmlTagName
 
 
 if exists('g:xml_syntax_folding')
+    command! -nargs=+ XmlContained <args> contained
+    command! -nargs=+ XmlFold <args> fold
+else
+    command! -nargs=+ XmlContained <args>
+    command! -nargs=+ XmlFold <args>
+endif
 
-    " start tag
-    " use matchgroup=xmlTag to skip over the leading '<'
-    "
-    " PROVIDES: @xmlStartTagHook
-    "
-    " EXAMPLE:
-    "
-    " <tag id="whoops">
-    " s^^^^^^^^^^^^^^^e
-    "
-    syn region   xmlTag
+" start tag
+" use matchgroup=xmlTag to skip over the leading '<'
+"
+" PROVIDES: @xmlStartTagHook
+"
+" EXAMPLE:
+"
+" <tag id="whoops">
+" s^^^^^^^^^^^^^^^e
+"
+XmlContained syn region   xmlTag
 	\ matchgroup=xmlTag start=+<\ze[^ /!?<>"']+
 	\ matchgroup=xmlTag end=+>+
-	\ contained
 	\ contains=xmlError,xmlTagName,xmlAttrib,xmlEqual,xmlString,@xmlStartTagHook
 
 
-    " highlight the end tag
-    "
-    " PROVIDES: @xmlTagHook
-    " (should we provide a separate @xmlEndTagHook ?)
-    "
-    " EXAMPLE:
-    "
-    " </tag>
-    " ^^^^^^
-    "
-    syn region   xmlEndTag
+" highlight the end tag
+"
+" PROVIDES: @xmlTagHook
+" (should we provide a separate @xmlEndTagHook ?)
+"
+" EXAMPLE:
+"
+" </tag>
+" ^^^^^^
+"
+XmlContained syn region   xmlEndTag
 	\ matchgroup=xmlTag start=+</\ze[^ /!?<>"']+
 	\ matchgroup=xmlTag end=+>+
-	\ contained
 	\ contains=xmlTagName,xmlNamespace,xmlAttribPunct,@xmlTagHook
 
+delcommand XmlContained
+
+
+if exists('g:xml_syntax_folding')
     " tag elements with syntax-folding.
     " NOTE: NO HIGHLIGHTING -- highlighting is done by contained elements
     "
@@ -215,23 +216,6 @@ if exists('g:xml_syntax_folding')
 	\ contains=xmlTag,xmlEndTag,xmlCdata,xmlRegion,xmlComment,xmlEntity,xmlProcessing,@xmlRegionHook,@Spell
 	\ keepend
 	\ extend
-
-else
-
-    " no syntax folding:
-    " - contained attribute removed
-    " - xmlRegion not defined
-    "
-    syn region   xmlTag
-	\ matchgroup=xmlTag start=+<\ze[^ /!?<>"']+
-	\ matchgroup=xmlTag end=+>+
-	\ contains=xmlError,xmlTagName,xmlAttrib,xmlEqual,xmlString,@xmlStartTagHook
-
-    syn region   xmlEndTag
-	\ matchgroup=xmlTag start=+</\ze[^ /!?<>"']+
-	\ matchgroup=xmlTag end=+>+
-	\ contains=xmlTagName,xmlNamespace,xmlAttribPunct,@xmlTagHook
-
 endif
 
 
@@ -239,29 +223,13 @@ endif
 syn match   xmlEntity                 "&[^; \t]*;" contains=xmlEntityPunct
 syn match   xmlEntityPunct  contained "[&.;]"
 
-if exists('g:xml_syntax_folding')
-
-    " The real comments (this implements the comments as defined by xml,
-    " but not all xml pages actually conform to it. Errors are flagged.
-    syn region  xmlComment
+" The real comments (this implements the comments as defined by xml,
+" but not all xml pages actually conform to it. Errors are flagged.
+XmlFold syn region  xmlComment
 	\ start=+<!+
 	\ end=+>+
 	\ contains=xmlCommentStart,xmlCommentError
 	\ extend
-	\ fold
-
-else
-
-    " no syntax folding:
-    " - fold attribute removed
-    "
-    syn region  xmlComment
-	\ start=+<!+
-	\ end=+>+
-	\ contains=xmlCommentStart,xmlCommentError
-	\ extend
-
-endif
 
 syn match xmlCommentStart   contained "<!" nextgroup=xmlCommentPart
 syn keyword xmlTodo         contained TODO FIXME XXX
@@ -296,23 +264,12 @@ syn match    xmlCdataEnd   +]]>+          contained
 syn region  xmlProcessing matchgroup=xmlProcessingDelim start="<?" end="?>" contains=xmlAttrib,xmlEqual,xmlString
 
 
-if exists('g:xml_syntax_folding')
-
-    " DTD -- we use dtd.vim here
-    syn region  xmlDocType matchgroup=xmlDocTypeDecl
-	\ start="<!DOCTYPE"he=s+2,rs=s+2 end=">"
-	\ fold
-	\ contains=xmlDocTypeKeyword,xmlInlineDTD,xmlString
-else
-
-    " no syntax folding:
-    " - fold attribute removed
-    "
-    syn region  xmlDocType matchgroup=xmlDocTypeDecl
+" DTD -- we use dtd.vim here
+XmlFold syn region  xmlDocType matchgroup=xmlDocTypeDecl
 	\ start="<!DOCTYPE"he=s+2,rs=s+2 end=">"
 	\ contains=xmlDocTypeKeyword,xmlInlineDTD,xmlString
 
-endif
+delcommand XmlFold
 
 syn keyword xmlDocTypeKeyword contained DOCTYPE PUBLIC SYSTEM
 syn region  xmlInlineDTD contained matchgroup=xmlDocTypeDecl start="\[" end="]" contains=@xmlDTD

--- a/syntax/xml.vim
+++ b/syntax/xml.vim
@@ -93,7 +93,7 @@ syn match   xmlEqual +=+ display
 "      ^^^^^^^^^^^^^
 "
 syn match   xmlAttrib
-    \ +[-'"<]\@1<!\<[a-zA-Z:_][-.0-9a-zA-Z:_]*\>\%(['"]\@!\|$\)+
+    \ +\%#=1[-'"<]\@1<!\<[a-zA-Z:_][-.0-9a-zA-Z:_]*\>['"]\@!+
     \ contained
     \ contains=xmlAttribPunct,@xmlAttribHook
     \ display

--- a/syntax/xml.vim
+++ b/syntax/xml.vim
@@ -62,7 +62,8 @@ syn case match
 syn spell toplevel
 
 " mark illegal characters
-syn match xmlError "[<&]"
+syn match xmlError "<"
+syn match xmlError "&"
 
 " strings (inside tags) aka VALUES
 "


### PR DESCRIPTION
I also snuck in a stylistic change at the end, namely so that `<?xml` at the start of the file does not get highlighted as `xmlAttrib`, but as `xmlProcessing`. The rest of my changes are optimizations and refactors.